### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <url>https://nexuslite.gcnt.net/repos/other/</url>
         </repository>
         <repository>
-            <id>nametagedit</id>
+            <id>upstream</id>
             <url>https://ci.nametagedit.com/plugin/repository/everything/</url>
         </repository>
         <repository>
@@ -246,8 +246,7 @@
         <dependency>
             <groupId>com.nametagedit</groupId>
             <artifactId>nametagedit</artifactId>
-            <version>4.5.6</version>
-            <scope>provided</scope>
+            <version>4.4.16</version>
         </dependency>
         <dependency>
             <groupId>com.viaversion</groupId>


### PR DESCRIPTION
Fixed Pom missing nametagedit, it seems 4.5.6 no longer exists in the old repo, 4.4.16 was buildable and seems fine to use.